### PR TITLE
Array.from shouldn't trigger noAssignMutatedArrayRule violation

### DIFF
--- a/source/rules/noAssignMutatedArrayRule.ts
+++ b/source/rules/noAssignMutatedArrayRule.ts
@@ -10,7 +10,7 @@ import * as ts from "typescript";
 import { couldBeType } from "../support";
 
 const mutatorRegExp = /^(fill|reverse|sort)$/;
-const creatorRegExp = /^(concat|entries|filter|keys|map|slice|splice|values)$/;
+const creatorRegExp = /^(concat|entries|filter|from|keys|map|slice|splice|values)$/;
 
 export class Rule extends Lint.Rules.TypedRule {
   public static metadata: Lint.IRuleMetadata = {


### PR DESCRIPTION
Long story short:

```js
const arr = Array.from(...).sort()
```

should be allowed.